### PR TITLE
Fix music embeds

### DIFF
--- a/src/pages/music/IframeLoader.tsx
+++ b/src/pages/music/IframeLoader.tsx
@@ -14,6 +14,7 @@ export const IframeLoader = (props: Props) => {
       <IframeContainer $loaded={loaded} $height={props.height}>
         <iframe
           onLoad={() => setLoaded(true)}
+          onError={() => setLoaded(true)}
           src={props.src}
           height={props.height}
           frameBorder="0"
@@ -46,6 +47,7 @@ const IframeContainer = styled.div<{ $loaded: boolean; $height: number }>`
   iframe {
     display: block;
     border-radius: 12px;
+    position: relative;
 
     height: ${p => p.$height}px;
     width: 100%;


### PR DESCRIPTION
- positioning was putting the `before` with the box shadow over the iframes
- add an onError to the iframe to fix the issue when privacy badger blocks it